### PR TITLE
ACK. zola upgrade changed paths and broke all links.

### DIFF
--- a/scripts-container/build.sh
+++ b/scripts-container/build.sh
@@ -14,7 +14,7 @@ IFS=$'\n\t'
 # ---- End unofficial bash strict mode boilerplate
 
 install_zola() {
-  ZOLA_VERSION=0.13.0
+  ZOLA_VERSION=0.7.0
   zola_url="https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
   # install zola
   mkdir -p ./local/bin


### PR DESCRIPTION
- In zola 0.7.0 it was /year/month/slug
- In zola 0.13.0 it seems to be /year-month-slug

Emergency revert to fix links